### PR TITLE
Add C translation service with AST translate methods

### DIFF
--- a/src/main/java/br/edu/pucgoias/brasilang/model/sintaxe/expression/AbstractExpression.java
+++ b/src/main/java/br/edu/pucgoias/brasilang/model/sintaxe/expression/AbstractExpression.java
@@ -1,5 +1,19 @@
 package br.edu.pucgoias.brasilang.model.sintaxe.expression;
 
+import br.edu.pucgoias.brasilang.translate.TranslationContext;
+
+/**
+ * Represents an expression node in the AST. Each expression knows how to
+ * translate itself to C code using the provided {@link TranslationContext}.
+ */
 public interface AbstractExpression {
 
+    /**
+     * Translates the expression into its C representation.
+     *
+     * @param ctx translation context with helper utilities
+     * @return the C code representing this expression
+     */
+    String translate(TranslationContext ctx);
 }
+

--- a/src/main/java/br/edu/pucgoias/brasilang/model/sintaxe/expression/BinaryOperation.java
+++ b/src/main/java/br/edu/pucgoias/brasilang/model/sintaxe/expression/BinaryOperation.java
@@ -1,5 +1,7 @@
 package br.edu.pucgoias.brasilang.model.sintaxe.expression;
 
+import br.edu.pucgoias.brasilang.translate.TranslationContext;
+
 public class BinaryOperation implements AbstractExpression{
         private String operator;
         private AbstractExpression leftExpression;
@@ -9,6 +11,11 @@ public class BinaryOperation implements AbstractExpression{
                 this.operator = operator;
                 this.leftExpression = leftExpression;
                 this.rightExpression = rightExpression;
+        }
+
+        @Override
+        public String translate(TranslationContext ctx) {
+                return leftExpression.translate(ctx) + " " + operator + " " + rightExpression.translate(ctx);
         }
 
         @Override

--- a/src/main/java/br/edu/pucgoias/brasilang/model/sintaxe/expression/FunctionCall.java
+++ b/src/main/java/br/edu/pucgoias/brasilang/model/sintaxe/expression/FunctionCall.java
@@ -1,0 +1,25 @@
+package br.edu.pucgoias.brasilang.model.sintaxe.expression;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import br.edu.pucgoias.brasilang.translate.TranslationContext;
+
+/** Expression representing a function invocation. */
+public class FunctionCall implements AbstractExpression {
+
+    private final String name;
+    private final List<AbstractExpression> arguments;
+
+    public FunctionCall(String name, List<AbstractExpression> arguments) {
+        this.name = name;
+        this.arguments = arguments;
+    }
+
+    @Override
+    public String translate(TranslationContext ctx) {
+        return name + "(" + arguments.stream()
+                .map(a -> a.translate(ctx))
+                .collect(Collectors.joining(", ")) + ")";
+    }
+}

--- a/src/main/java/br/edu/pucgoias/brasilang/model/sintaxe/expression/Literal.java
+++ b/src/main/java/br/edu/pucgoias/brasilang/model/sintaxe/expression/Literal.java
@@ -1,5 +1,7 @@
 package br.edu.pucgoias.brasilang.model.sintaxe.expression;
 
+import br.edu.pucgoias.brasilang.translate.TranslationContext;
+
 public class Literal implements AbstractExpression{
 	
 	private Object value;
@@ -9,6 +11,14 @@ public class Literal implements AbstractExpression{
                 this.value = value;
         }
 
+
+        @Override
+        public String translate(TranslationContext ctx) {
+                if (value instanceof String) {
+                        return "\"" + value + "\"";
+                }
+                return String.valueOf(value);
+        }
 
         @Override
         public String toString() {

--- a/src/main/java/br/edu/pucgoias/brasilang/model/sintaxe/expression/UnaryOperation.java
+++ b/src/main/java/br/edu/pucgoias/brasilang/model/sintaxe/expression/UnaryOperation.java
@@ -1,5 +1,7 @@
 package br.edu.pucgoias.brasilang.model.sintaxe.expression;
 
+import br.edu.pucgoias.brasilang.translate.TranslationContext;
+
 public class UnaryOperation implements AbstractExpression {
         private String operator;
         private AbstractExpression expression;
@@ -7,6 +9,11 @@ public class UnaryOperation implements AbstractExpression {
         public UnaryOperation(String operator, AbstractExpression expression) {
                 this.operator = operator;
                 this.expression = expression;
+        }
+
+        @Override
+        public String translate(TranslationContext ctx) {
+                return operator + expression.translate(ctx);
         }
 
         @Override

--- a/src/main/java/br/edu/pucgoias/brasilang/model/sintaxe/expression/Variable.java
+++ b/src/main/java/br/edu/pucgoias/brasilang/model/sintaxe/expression/Variable.java
@@ -1,5 +1,7 @@
 package br.edu.pucgoias.brasilang.model.sintaxe.expression;
 
+import br.edu.pucgoias.brasilang.translate.TranslationContext;
+
 public class Variable implements AbstractExpression {
 	
 	private String name;
@@ -9,6 +11,11 @@ public class Variable implements AbstractExpression {
                 this.name = name;
         }
 
+
+        @Override
+        public String translate(TranslationContext ctx) {
+                return name;
+        }
 
         @Override
         public String toString() {

--- a/src/main/java/br/edu/pucgoias/brasilang/model/sintaxe/statement/AbstractStatement.java
+++ b/src/main/java/br/edu/pucgoias/brasilang/model/sintaxe/statement/AbstractStatement.java
@@ -1,5 +1,20 @@
 package br.edu.pucgoias.brasilang.model.sintaxe.statement;
 
+import br.edu.pucgoias.brasilang.translate.TranslationContext;
+
+/**
+ * Base interface for all statement nodes in the AST. Statements append their
+ * translated C code directly to the {@link TranslationContext}'s
+ * {@code CodeBuilder}.
+ */
 public interface AbstractStatement {
 
+    /**
+     * Emits the C code representation for this statement using the provided
+     * translation context.
+     *
+     * @param ctx translation context with helper utilities
+     */
+    void translate(TranslationContext ctx);
 }
+

--- a/src/main/java/br/edu/pucgoias/brasilang/model/sintaxe/statement/Assign.java
+++ b/src/main/java/br/edu/pucgoias/brasilang/model/sintaxe/statement/Assign.java
@@ -2,6 +2,7 @@ package br.edu.pucgoias.brasilang.model.sintaxe.statement;
 
 
 import br.edu.pucgoias.brasilang.model.sintaxe.expression.AbstractExpression;
+import br.edu.pucgoias.brasilang.translate.TranslationContext;
 
 public class Assign implements AbstractStatement {
 
@@ -12,6 +13,12 @@ public class Assign implements AbstractStatement {
                 super();
                 this.variableName = variableName;
                 this.newValue = newValue;
+        }
+
+        @Override
+        public void translate(TranslationContext ctx) {
+                ctx.getBuilder()
+                        .appendLine(variableName + " = " + newValue.translate(ctx) + ";");
         }
 
         @Override

--- a/src/main/java/br/edu/pucgoias/brasilang/model/sintaxe/statement/ConditionalStruct.java
+++ b/src/main/java/br/edu/pucgoias/brasilang/model/sintaxe/statement/ConditionalStruct.java
@@ -3,6 +3,7 @@ package br.edu.pucgoias.brasilang.model.sintaxe.statement;
 import java.util.List;
 
 import br.edu.pucgoias.brasilang.model.sintaxe.expression.AbstractExpression;
+import br.edu.pucgoias.brasilang.translate.TranslationContext;
 
 public class ConditionalStruct implements AbstractStatement {
 	
@@ -15,6 +16,25 @@ public class ConditionalStruct implements AbstractStatement {
                 this.flag = flag;
                 this.ifBody = ifBody;
                 this.elseBody = elseBody;
+        }
+
+        @Override
+        public void translate(TranslationContext ctx) {
+                ctx.getBuilder().appendLine("if (" + flag.translate(ctx) + ") {");
+                ctx.getBuilder().indent();
+                for (AbstractStatement st : ifBody) {
+                        st.translate(ctx);
+                }
+                ctx.getBuilder().outdent();
+                if (elseBody != null && !elseBody.isEmpty()) {
+                        ctx.getBuilder().appendLine("} else {");
+                        ctx.getBuilder().indent();
+                        for (AbstractStatement st : elseBody) {
+                                st.translate(ctx);
+                        }
+                        ctx.getBuilder().outdent();
+                }
+                ctx.getBuilder().appendLine("}");
         }
 
         @Override

--- a/src/main/java/br/edu/pucgoias/brasilang/model/sintaxe/statement/FunctionDeclaration.java
+++ b/src/main/java/br/edu/pucgoias/brasilang/model/sintaxe/statement/FunctionDeclaration.java
@@ -1,0 +1,49 @@
+package br.edu.pucgoias.brasilang.model.sintaxe.statement;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import br.edu.pucgoias.brasilang.model.lexico.EnumTokenType;
+import br.edu.pucgoias.brasilang.translate.TranslationContext;
+
+/** Represents a function definition. */
+public class FunctionDeclaration implements AbstractStatement {
+
+    public static class Parameter {
+        public final String name;
+        public final EnumTokenType type;
+
+        public Parameter(String name, EnumTokenType type) {
+            this.name = name;
+            this.type = type;
+        }
+    }
+
+    private final EnumTokenType returnType;
+    private final String name;
+    private final List<Parameter> parameters;
+    private final List<AbstractStatement> body;
+
+    public FunctionDeclaration(EnumTokenType returnType, String name, List<Parameter> parameters,
+            List<AbstractStatement> body) {
+        this.returnType = returnType;
+        this.name = name;
+        this.parameters = parameters;
+        this.body = body;
+    }
+
+    @Override
+    public void translate(TranslationContext ctx) {
+        String params = parameters.stream()
+                .map(p -> ctx.toCType(p.type) + " " + p.name)
+                .collect(Collectors.joining(", "));
+        ctx.getBuilder().appendLine(ctx.toCType(returnType) + " " + name + "(" + params + ") {");
+        ctx.getBuilder().indent();
+        for (AbstractStatement st : body) {
+            st.translate(ctx);
+        }
+        ctx.getBuilder().outdent();
+        ctx.getBuilder().appendLine("}");
+        ctx.getBuilder().appendLine("");
+    }
+}

--- a/src/main/java/br/edu/pucgoias/brasilang/model/sintaxe/statement/Print.java
+++ b/src/main/java/br/edu/pucgoias/brasilang/model/sintaxe/statement/Print.java
@@ -1,6 +1,7 @@
 package br.edu.pucgoias.brasilang.model.sintaxe.statement;
 
 import br.edu.pucgoias.brasilang.model.sintaxe.expression.AbstractExpression;
+import br.edu.pucgoias.brasilang.translate.TranslationContext;
 
 public class Print implements AbstractStatement {
 
@@ -12,6 +13,12 @@ public class Print implements AbstractStatement {
 
     public AbstractExpression getExpression() {
         return expression;
+    }
+
+    @Override
+    public void translate(TranslationContext ctx) {
+        ctx.addInclude("<stdio.h>");
+        ctx.getBuilder().appendLine("printf(" + expression.translate(ctx) + ");");
     }
 
     @Override

--- a/src/main/java/br/edu/pucgoias/brasilang/model/sintaxe/statement/Program.java
+++ b/src/main/java/br/edu/pucgoias/brasilang/model/sintaxe/statement/Program.java
@@ -1,0 +1,26 @@
+package br.edu.pucgoias.brasilang.model.sintaxe.statement;
+
+import java.util.List;
+
+import br.edu.pucgoias.brasilang.translate.TranslationContext;
+
+/** Root of the AST containing top-level statements. */
+public class Program implements AbstractStatement {
+
+    private final List<AbstractStatement> statements;
+
+    public Program(List<AbstractStatement> statements) {
+        this.statements = statements;
+    }
+
+    public List<AbstractStatement> getStatements() {
+        return statements;
+    }
+
+    @Override
+    public void translate(TranslationContext ctx) {
+        for (AbstractStatement st : statements) {
+            st.translate(ctx);
+        }
+    }
+}

--- a/src/main/java/br/edu/pucgoias/brasilang/model/sintaxe/statement/RepetitionStruct.java
+++ b/src/main/java/br/edu/pucgoias/brasilang/model/sintaxe/statement/RepetitionStruct.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import br.edu.pucgoias.brasilang.model.lexico.EnumTokenType;
 import br.edu.pucgoias.brasilang.model.sintaxe.expression.AbstractExpression;
+import br.edu.pucgoias.brasilang.translate.TranslationContext;
 
 public class RepetitionStruct implements AbstractStatement{
 	
@@ -18,6 +19,23 @@ public class RepetitionStruct implements AbstractStatement{
         }
 
 
+
+        @Override
+        public void translate(TranslationContext ctx) {
+                String header;
+                if (type == EnumTokenType.ENQUANTO) {
+                        header = "while (" + flag.translate(ctx) + ") {";
+                } else {
+                        header = "for (; " + flag.translate(ctx) + "; ) {";
+                }
+                ctx.getBuilder().appendLine(header);
+                ctx.getBuilder().indent();
+                for (AbstractStatement st : loopBody) {
+                        st.translate(ctx);
+                }
+                ctx.getBuilder().outdent();
+                ctx.getBuilder().appendLine("}");
+        }
 
         @Override
         public String toString() {

--- a/src/main/java/br/edu/pucgoias/brasilang/model/sintaxe/statement/ReturnStatement.java
+++ b/src/main/java/br/edu/pucgoias/brasilang/model/sintaxe/statement/ReturnStatement.java
@@ -1,0 +1,19 @@
+package br.edu.pucgoias.brasilang.model.sintaxe.statement;
+
+import br.edu.pucgoias.brasilang.model.sintaxe.expression.AbstractExpression;
+import br.edu.pucgoias.brasilang.translate.TranslationContext;
+
+/** Statement that returns a value from a function. */
+public class ReturnStatement implements AbstractStatement {
+
+    private final AbstractExpression expression;
+
+    public ReturnStatement(AbstractExpression expression) {
+        this.expression = expression;
+    }
+
+    @Override
+    public void translate(TranslationContext ctx) {
+        ctx.getBuilder().appendLine("return " + expression.translate(ctx) + ";");
+    }
+}

--- a/src/main/java/br/edu/pucgoias/brasilang/model/sintaxe/statement/VariableDeclaration.java
+++ b/src/main/java/br/edu/pucgoias/brasilang/model/sintaxe/statement/VariableDeclaration.java
@@ -2,6 +2,7 @@ package br.edu.pucgoias.brasilang.model.sintaxe.statement;
 
 import br.edu.pucgoias.brasilang.model.lexico.EnumTokenType;
 import br.edu.pucgoias.brasilang.model.sintaxe.expression.AbstractExpression;
+import br.edu.pucgoias.brasilang.translate.TranslationContext;
 
 
 public class VariableDeclaration implements AbstractStatement{
@@ -15,6 +16,18 @@ public class VariableDeclaration implements AbstractStatement{
                 this.variableName = variableName;
                 this.tokenType = tokenType;
                 this.initialization = initialization;
+        }
+
+        @Override
+        public void translate(TranslationContext ctx) {
+                String cType = ctx.toCType(tokenType);
+                ctx.declareVariable(variableName, cType);
+                String line = cType + " " + variableName;
+                if (initialization != null) {
+                        line += " = " + initialization.translate(ctx);
+                }
+                line += ";";
+                ctx.getBuilder().appendLine(line);
         }
 
         @Override

--- a/src/main/java/br/edu/pucgoias/brasilang/translate/CodeBuilder.java
+++ b/src/main/java/br/edu/pucgoias/brasilang/translate/CodeBuilder.java
@@ -1,0 +1,17 @@
+package br.edu.pucgoias.brasilang.translate;
+
+/** Utility to help building C code with proper indentation. */
+public class CodeBuilder {
+
+    private final StringBuilder sb = new StringBuilder();
+    private int indent = 0;
+
+    public void indent() { indent++; }
+    public void outdent() { if (indent > 0) indent--; }
+
+    public void appendLine(String line) {
+        sb.append("    ".repeat(indent)).append(line).append("\n");
+    }
+
+    public String build() { return sb.toString(); }
+}

--- a/src/main/java/br/edu/pucgoias/brasilang/translate/TranslateService.java
+++ b/src/main/java/br/edu/pucgoias/brasilang/translate/TranslateService.java
@@ -1,0 +1,49 @@
+package br.edu.pucgoias.brasilang.translate;
+
+import br.edu.pucgoias.brasilang.model.sintaxe.statement.AbstractStatement;
+import br.edu.pucgoias.brasilang.model.sintaxe.statement.FunctionDeclaration;
+import br.edu.pucgoias.brasilang.model.sintaxe.statement.Program;
+
+/** Service responsible for orchestrating AST translation to C code. */
+public class TranslateService {
+
+    private final Program program;
+
+    public TranslateService(Program program) {
+        this.program = program;
+    }
+
+    /** Generates complete C source code for the provided AST. */
+    public String generateCode() {
+        CodeBuilder builder = new CodeBuilder();
+        TranslationContext ctx = new TranslationContext(builder);
+
+        // Emit function declarations before main
+        for (AbstractStatement st : program.getStatements()) {
+            if (st instanceof FunctionDeclaration) {
+                st.translate(ctx);
+            }
+        }
+
+        builder.appendLine("int main() {");
+        builder.indent();
+        for (AbstractStatement st : program.getStatements()) {
+            if (!(st instanceof FunctionDeclaration)) {
+                st.translate(ctx);
+            }
+        }
+        builder.appendLine("return 0;");
+        builder.outdent();
+        builder.appendLine("}");
+
+        StringBuilder finalCode = new StringBuilder();
+        for (String inc : ctx.getIncludes()) {
+            finalCode.append("#include ").append(inc).append("\n");
+        }
+        if (!ctx.getIncludes().isEmpty()) {
+            finalCode.append("\n");
+        }
+        finalCode.append(builder.build());
+        return finalCode.toString();
+    }
+}

--- a/src/main/java/br/edu/pucgoias/brasilang/translate/TranslationContext.java
+++ b/src/main/java/br/edu/pucgoias/brasilang/translate/TranslationContext.java
@@ -1,0 +1,39 @@
+package br.edu.pucgoias.brasilang.translate;
+
+import java.util.LinkedHashSet;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import br.edu.pucgoias.brasilang.model.lexico.EnumTokenType;
+
+/** Holds contextual information during translation to C. */
+public class TranslationContext {
+
+    private final CodeBuilder builder;
+    private final Set<String> includes = new LinkedHashSet<>();
+    private final Map<String, String> variables = new HashMap<>();
+
+    public TranslationContext(CodeBuilder builder) {
+        this.builder = builder;
+    }
+
+    public CodeBuilder getBuilder() { return builder; }
+
+    public void addInclude(String include) { includes.add(include); }
+    public Set<String> getIncludes() { return includes; }
+
+    public void declareVariable(String name, String type) { variables.put(name, type); }
+    public Map<String, String> getVariables() { return variables; }
+
+    public String toCType(EnumTokenType type) {
+        if (type == null) return "int";
+        return switch (type) {
+            case INT -> "int";
+            case FLOAT -> "float";
+            case DOUBLE -> "double";
+            case VOID -> "void";
+            default -> "int";
+        };
+    }
+}

--- a/src/test/java/br/edu/pucgoias/brasilang/translate/TranslateServiceTest.java
+++ b/src/test/java/br/edu/pucgoias/brasilang/translate/TranslateServiceTest.java
@@ -1,0 +1,106 @@
+package br.edu.pucgoias.brasilang.translate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import br.edu.pucgoias.brasilang.model.lexico.EnumTokenType;
+import br.edu.pucgoias.brasilang.model.sintaxe.expression.*;
+import br.edu.pucgoias.brasilang.model.sintaxe.statement.*;
+
+public class TranslateServiceTest {
+
+    @Test
+    void testVariableDeclarationTranslation() {
+        Program program = new Program(List.of(
+                new VariableDeclaration("x", EnumTokenType.INT, new Literal(10))));
+        String code = new TranslateService(program).generateCode();
+        String expected = "int main() {\n" +
+                "    int x = 10;\n" +
+                "    return 0;\n" +
+                "}\n";
+        assertEquals(expected, code);
+    }
+
+    @Test
+    void testFunctionTranslation() {
+        FunctionDeclaration soma = new FunctionDeclaration(
+                EnumTokenType.INT,
+                "soma",
+                List.of(new FunctionDeclaration.Parameter("a", EnumTokenType.INT),
+                        new FunctionDeclaration.Parameter("b", EnumTokenType.INT)),
+                List.of(new ReturnStatement(new BinaryOperation("+", new Variable("a"), new Variable("b")))));
+
+        Program program = new Program(List.of(
+                soma,
+                new Print(new FunctionCall("soma",
+                        List.of(new Literal(2), new Literal(3))))));
+
+        String code = new TranslateService(program).generateCode();
+        String expected = "#include <stdio.h>\n" +
+                "\n" +
+                "int soma(int a, int b) {\n" +
+                "    return a + b;\n" +
+                "}\n" +
+                "\n" +
+                "int main() {\n" +
+                "    printf(soma(2, 3));\n" +
+                "    return 0;\n" +
+                "}\n";
+        assertEquals(expected, code);
+    }
+
+    @Test
+    void testControlStructuresTranslation() {
+        VariableDeclaration i = new VariableDeclaration("i", EnumTokenType.INT, new Literal(0));
+        RepetitionStruct whileLoop = new RepetitionStruct(
+                EnumTokenType.ENQUANTO,
+                new BinaryOperation("<", new Variable("i"), new Literal(3)),
+                List.of(new Assign("i", new BinaryOperation("+", new Variable("i"), new Literal(1)))));
+        RepetitionStruct forLoop = new RepetitionStruct(
+                EnumTokenType.PARA,
+                new BinaryOperation("<", new Variable("i"), new Literal(5)),
+                List.of(new Assign("i", new BinaryOperation("+", new Variable("i"), new Literal(1)))));
+        ConditionalStruct cond = new ConditionalStruct(
+                new BinaryOperation("==", new Variable("i"), new Literal(5)),
+                List.of(new Print(new Literal("done"))),
+                List.of(new Print(new Literal("not done"))));
+
+        Program program = new Program(List.of(i, whileLoop, forLoop, cond));
+        String code = new TranslateService(program).generateCode();
+        String expected = "#include <stdio.h>\n" +
+                "\n" +
+                "int main() {\n" +
+                "    int i = 0;\n" +
+                "    while (i < 3) {\n" +
+                "        i = i + 1;\n" +
+                "    }\n" +
+                "    for (; i < 5; ) {\n" +
+                "        i = i + 1;\n" +
+                "    }\n" +
+                "    if (i == 5) {\n" +
+                "        printf(\"done\");\n" +
+                "    } else {\n" +
+                "        printf(\"not done\");\n" +
+                "    }\n" +
+                "    return 0;\n" +
+                "}\n";
+        assertEquals(expected, code);
+    }
+
+    @Test
+    void testHelloWorldTranslation() {
+        Program program = new Program(List.of(
+                new Print(new Literal("Hello, World!"))));
+        String code = new TranslateService(program).generateCode();
+        String expected = "#include <stdio.h>\n" +
+                "\n" +
+                "int main() {\n" +
+                "    printf(\"Hello, World!\");\n" +
+                "    return 0;\n" +
+                "}\n";
+        assertEquals(expected, code);
+    }
+}


### PR DESCRIPTION
## Summary
- add translation methods to expressions and statements
- introduce TranslateService, TranslationContext and CodeBuilder to generate C code
- cover variables, functions and control structures with tests

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for br.edu.pucgoias:brasilang due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c5de8195f483309926b00dceb308ce