### PR TITLE
Fix literal translation and expand language demo

### DIFF
--- a/src/main/java/br/edu/pucgoias/brasilang/BrasilangApplication.java
+++ b/src/main/java/br/edu/pucgoias/brasilang/BrasilangApplication.java
@@ -35,17 +35,24 @@ public class BrasilangApplication {
     @PostConstruct
     void executar() {
         List<Token> tokenList = new ArrayList<>();
-    	String src = """
-    			inteiro g = 10; // demo
-    			inteiro i = 0; 
-    			enquanto (i < 10) {
-    			  se (i == 5) {
-    			    imprima(55);
-    			  }
-    			  imprima(i);
-    			  i = i + 1;
-    			}
-    			""";
+        String src = """
+                        inteiro g = 10;
+                        flutuante f = 1.5;
+                        inteiro i = 0;
+                        para (i < 3) {
+                          imprima(i);
+                          i = i + 1;
+                        }
+                        enquanto (g > 0) {
+                          se (g == 5) {
+                            imprima("metade");
+                          } senao {
+                            imprima(g);
+                          }
+                          g = g - 1;
+                        }
+                        imprima(f);
+                        """;
     	Lexer lexer = new Lexer(src);
     	Token currentToken;
         do {

--- a/src/main/java/br/edu/pucgoias/brasilang/model/sintaxe/expression/Literal.java
+++ b/src/main/java/br/edu/pucgoias/brasilang/model/sintaxe/expression/Literal.java
@@ -4,11 +4,15 @@ import br.edu.pucgoias.brasilang.translate.TranslationContext;
 
 public class Literal implements AbstractExpression{
 	
-	private Object value;
+        private Object value;
 
         public Literal(Object value) {
                 super();
                 this.value = value;
+        }
+
+        public Object getValue() {
+                return value;
         }
 
 

--- a/src/main/java/br/edu/pucgoias/brasilang/model/sintaxe/expression/Variable.java
+++ b/src/main/java/br/edu/pucgoias/brasilang/model/sintaxe/expression/Variable.java
@@ -4,11 +4,15 @@ import br.edu.pucgoias.brasilang.translate.TranslationContext;
 
 public class Variable implements AbstractExpression {
 	
-	private String name;
+        private String name;
 
         public Variable(String name) {
                 super();
                 this.name = name;
+        }
+
+        public String getName() {
+                return name;
         }
 
 

--- a/src/main/java/br/edu/pucgoias/brasilang/model/sintaxe/statement/Print.java
+++ b/src/main/java/br/edu/pucgoias/brasilang/model/sintaxe/statement/Print.java
@@ -1,6 +1,8 @@
 package br.edu.pucgoias.brasilang.model.sintaxe.statement;
 
 import br.edu.pucgoias.brasilang.model.sintaxe.expression.AbstractExpression;
+import br.edu.pucgoias.brasilang.model.sintaxe.expression.Literal;
+import br.edu.pucgoias.brasilang.model.sintaxe.expression.Variable;
 import br.edu.pucgoias.brasilang.translate.TranslationContext;
 
 public class Print implements AbstractStatement {
@@ -18,13 +20,28 @@ public class Print implements AbstractStatement {
     @Override
     public void translate(TranslationContext ctx) {
         ctx.addInclude("<stdio.h>");
-        ctx.getBuilder().appendLine("printf(" + expression.translate(ctx) + ");");
+        String exprCode = expression.translate(ctx);
+        String format = "%d";
+        if (expression instanceof Literal lit) {
+            Object val = lit.getValue();
+            if (val instanceof String) {
+                format = "%s";
+            } else if (val instanceof Float || val instanceof Double) {
+                format = "%f";
+            }
+        } else if (expression instanceof Variable var) {
+            String type = ctx.getVariables().get(var.getName());
+            if ("float".equals(type) || "double".equals(type)) {
+                format = "%f";
+            }
+        }
+        ctx.getBuilder().appendLine("printf(\"" + format + "\", " + exprCode + ");");
     }
 
-@Override
-public String toString() {
-return "Print{\n" +
-"  expression=" + expression + "\n" +
-"}";
-}
+    @Override
+    public String toString() {
+        return "Print{\n" +
+                "  expression=" + expression + "\n" +
+                "}"; 
+    }
 }

--- a/src/main/java/br/edu/pucgoias/brasilang/service/SintaxeService.java
+++ b/src/main/java/br/edu/pucgoias/brasilang/service/SintaxeService.java
@@ -45,6 +45,8 @@ public class SintaxeService {
 
             switch (token.type) {
                 case INT:
+                case FLOAT:
+                case DOUBLE:
                     return parseVariableDeclaration(sintaxe, token);
                 case ID:
                     return parseAssign(sintaxe, token);
@@ -200,7 +202,9 @@ public class SintaxeService {
             }
             switch (token.type) {
                 case INTLIT:
+                    return new Literal(Integer.parseInt(token.lexeme));
                 case FLOATLIT:
+                    return new Literal(Double.parseDouble(token.lexeme));
                 case STRINGLIT:
                     return new Literal(token.lexeme);
                 case ID:


### PR DESCRIPTION
## Summary
- Parse numeric literals as primitive values to avoid quotes in generated C code
- Add format-aware print translation and helper getters
- Expand demo program to showcase variable types, loops, conditionals and string output

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c631343478833095aff68610b0f1be